### PR TITLE
Add loader while uploading images in summernote editor

### DIFF
--- a/django_summernote/templates/django_summernote/widget_common.html
+++ b/django_summernote/templates/django_summernote/widget_common.html
@@ -93,6 +93,11 @@ function initSummernote_{{ id_safe }}() {
                     {% if not config.disable_attachment %}
                     onImageUpload: function(files) {
                         // custom attachment data
+                        if ($(".note-editable")[0]){
+                            var s = '<img id="loader" src="https://media3.giphy.com/media/3oEjI6SIIHBdRxXI40/giphy.gif">';
+
+                            $(".note-editable")[0].innerHTML = s + $(".note-editable")[0].innerHTML
+                        }
                         var attachmentData = origin.dataset;
                         $nImageInput = $nEditor.find('.note-image-input');
                         $nImageInput.fileupload();
@@ -103,11 +108,13 @@ function initSummernote_{{ id_safe }}() {
                                 url: settings.url.upload_attachment,
                             })
                             .done(function (data, textStatus, jqXHR) {
+                                $("#loader").remove()
                                 $.each(data.files, function (index, file) {
                                     $sn.summernote("insertImage", file.url);
                                 });
                             })
                             .fail(function (jqXHR, textStatus, errorThrown) {
+                                $("#loader").remove()
                                 // if the error message from the server has any text in it, show it
                                 var msg = jqXHR.responseJSON;
                                 if (msg && msg.message) {


### PR DESCRIPTION
### Task description

To add loader while uploading images in django summernote.

### Implementation details

To add loader as discussed in the ticket, the approach that was finalised was to fork django summernote and use it in srv-ergeon after adding loader to it.

### Demo and testing

Successfully able to create loader.


https://user-images.githubusercontent.com/121093595/209122965-8599328a-7a71-4102-acb6-286cdc8ba6d6.mp4



### Dependencies

This repo has to be added in poetry.lock in srv-ergeon.
